### PR TITLE
feat: istanbul ignore if is browser

### DIFF
--- a/lib/ml/index.js
+++ b/lib/ml/index.js
@@ -61,6 +61,11 @@ const services = {
   $activeSheet,
 }
 
+/* istanbul ignore if */
+if (typeof window !== 'undefined' && window.Vue) {
+  install(components, services)(window.Vue)
+}
+
 /**
  * Export default Object
  *


### PR DESCRIPTION
- When compatible developers use cdn to get vue directly.
- `ML-UI` can also provide a complete packaged CDN